### PR TITLE
Add fixvx.com as tweet URL host option

### DIFF
--- a/ModernSettingsViewController.m
+++ b/ModernSettingsViewController.m
@@ -2203,11 +2203,16 @@ static UIFont *TwitterChirpFont(TwitterFontStyle style) {
         [[NSUserDefaults standardUserDefaults] setObject:@"vxtwitter.com" forKey:@"tweet_url_host"];
         if (indexPath) [self.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationNone];
     }];
+    UIAlertAction *fixvxHostAction = [UIAlertAction actionWithTitle:@"fixvx.com" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+        [[NSUserDefaults standardUserDefaults] setObject:@"fixvx.com" forKey:@"tweet_url_host"];
+        if (indexPath) [self.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationNone];
+    }];
     UIAlertAction *cancel = [UIAlertAction actionWithTitle:[[BHTBundle sharedBundle] localizedStringForKey:@"CANCEL_BUTTON_TITLE"] style:UIAlertActionStyleCancel handler:nil];
     [alert addAction:xHostAction];
     [alert addAction:twitterHostAction];
     [alert addAction:fxHostAction];
     [alert addAction:vxHostAction];
+    [alert addAction:fixvxHostAction];
     [alert addAction:cancel];
     [self presentViewController:alert animated:true completion:nil];
 }

--- a/SettingsViewController.m
+++ b/SettingsViewController.m
@@ -912,6 +912,11 @@ PSSpecifier *photosVideosSection = [self newSectionWithTitle:[[BHTBundle sharedB
         [selectionSpecifier setProperty:@"vxtwitter.com" forKey:@"subtitle"];
         [self reloadSpecifiers];
     }];
+    UIAlertAction *fixvxHostAction = [UIAlertAction actionWithTitle:@"fixvx.com" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+        [[NSUserDefaults standardUserDefaults] setObject:@"fixvx.com" forKey:@"tweet_url_host"];
+        [selectionSpecifier setProperty:@"fixvx.com" forKey:@"subtitle"];
+        [self reloadSpecifiers];
+    }];
 
     UIAlertAction *cancel = [UIAlertAction actionWithTitle:[[BHTBundle sharedBundle] localizedStringForKey:@"CANCEL_BUTTON_TITLE"] style:UIAlertActionStyleCancel handler:nil];
     
@@ -919,6 +924,7 @@ PSSpecifier *photosVideosSection = [self newSectionWithTitle:[[BHTBundle sharedB
     [alert addAction:twitterHostAction];
     [alert addAction:fxHostAction];
     [alert addAction:vxHostAction];
+    [alert addAction:fixvxHostAction];
     [alert addAction:cancel];
     
     [self presentViewController:alert animated:true completion:nil];


### PR DESCRIPTION
As the title says, adds `fixvx.com` as a tweet URL host option. I like it mostly just because it's shorter than fxtwitter/vxtwitter.